### PR TITLE
Update deployment docs and refactor string formatting to strconv

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,12 @@ JWT_REFRESH_TOKEN_TTL=168h
 ### Cloud Deployment
 
 #### Railway
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/your-template-id)
+> **Note:** Railway telah menghentikan dukungan untuk template deployment gratis. Silakan gunakan opsi lain di bawah ini atau deploy secara manual.
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new)
 
 #### Render
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ilramdhan/holidayapi)
 
 #### Fly.io
 ```bash

--- a/internal/repository/holiday_repository.go
+++ b/internal/repository/holiday_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -89,17 +90,17 @@ func (r *holidayRepository) GetAll(filter models.HolidayFilter) ([]models.Holida
 
 	if filter.Year != nil {
 		whereConditions = append(whereConditions, "strftime('%Y', date) = ?")
-		args = append(args, fmt.Sprintf("%d", *filter.Year))
+		args = append(args, strconv.Itoa(*filter.Year))
 	}
 
 	if filter.Month != nil {
 		whereConditions = append(whereConditions, "strftime('%m', date) = ?")
-		args = append(args, fmt.Sprintf("%02d", *filter.Month))
+		args = append(args, strconv.Itoa(*filter.Month))
 	}
 
 	if filter.Day != nil {
 		whereConditions = append(whereConditions, "strftime('%d', date) = ?")
-		args = append(args, fmt.Sprintf("%02d", *filter.Day))
+		args = append(args, strconv.Itoa(*filter.Day))
 	}
 
 	if filter.Type != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -101,10 +102,10 @@ func (c *Client) GetHolidays(ctx context.Context, year, month *int, holidayType 
 
 	q := req.URL.Query()
 	if year != nil {
-		q.Add("year", fmt.Sprintf("%d", *year))
+		q.Add("year", strconv.Itoa(*year))
 	}
 	if month != nil {
-		q.Add("month", fmt.Sprintf("%d", *month))
+		q.Add("month", strconv.Itoa(*month))
 	}
 	if holidayType != "" {
 		q.Add("type", holidayType)


### PR DESCRIPTION
Update deployment docs and refactor string formatting to strconv

## Description
Updates README.md with Railway deprecation note and fixes deployment links. Refactors string formatting from fmt.Sprintf to strconv.Itoa for consistency.

## Type of Change
- [x] 📚 Documentation update
- [x] 🎨 Code style/formatting
- [x] ♻️ Code refactoring

## Changes Made
1. Update README.md with Railway deprecation note and fixed deployment links
2. Replace fmt.Sprintf with strconv.Itoa for year/month/day formatting in holiday_repository.go
3. Replace fmt.Sprintf with strconv.Itoa in pkg/client/client.go for consistency

## How Has This Been Tested?
- Manual testing on Linux